### PR TITLE
Temporarily make static linking of sentencepiece the default

### DIFF
--- a/sentencepiece-sys/Cargo.toml
+++ b/sentencepiece-sys/Cargo.toml
@@ -17,5 +17,9 @@ cmake = "0.1"
 pkg-config = "0.3"
 
 [features]
+# Static linking is the default until the following issue is resolved:
+# https://github.com/google/sentencepiece/issues/579
+default = [ "static" ]
+
 system = []
 static = []


### PR DESCRIPTION
Dynamic linking can lead to incompatibilities. This change can be
reverted once

https://github.com/google/sentencepiece/issues/579

is resolved.
