### PR TITLE
Add `SentencePieceProcessor::sample_encode` method

### DIFF
--- a/sentencepiece-sys/src/bindings.rs
+++ b/sentencepiece-sys/src/bindings.rs
@@ -810,6 +810,16 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
+    pub fn spp_sample_encode_as_serialized_proto(
+        spp: *mut SentencePieceProcessor,
+        sentence: *const ::std::os::raw::c_char,
+        sentence_len: size_t,
+        len: *mut size_t,
+        nbest: size_t,
+        alpha: f32,
+    ) -> *mut ::std::os::raw::c_uchar;
+}
+extern "C" {
     pub fn spp_new() -> *mut SentencePieceProcessor;
 }
 extern "C" {

--- a/sentencepiece-sys/src/ffi/sentencepiece.cpp
+++ b/sentencepiece-sys/src/ffi/sentencepiece.cpp
@@ -57,6 +57,18 @@ unsigned char *spp_encode_as_serialized_proto(SentencePieceProcessor *spp, char 
   return data;
 }
 
+
+unsigned char *spp_sample_encode_as_serialized_proto(SentencePieceProcessor *spp, char const *sentence, size_t sentence_len, size_t *len, size_t nbest, float alpha) {
+  auto sentence_view = absl::string_view(sentence, sentence_len);
+  auto serialized = spp->SampleEncodeAsSerializedProto(sentence_view, static_cast<int>(nbest), alpha);
+
+  *len = serialized.size();
+  unsigned char *data = (unsigned char *) malloc(serialized.size());
+  memcpy(data, serialized.data(), serialized.size());
+
+  return data;
+}
+
 int spp_eos_id(SentencePieceProcessor *spp) {
   return spp->eos_id();
 }

--- a/sentencepiece-sys/src/ffi/sentencepiece.h
+++ b/sentencepiece-sys/src/ffi/sentencepiece.h
@@ -14,6 +14,8 @@ int spp_decode_piece_ids(SentencePieceProcessor *spp, uint32_t const *pieces, si
 
 unsigned char *spp_encode_as_serialized_proto(SentencePieceProcessor *spp, char const *sentence, size_t sentence_len, size_t *len);
 
+unsigned char *spp_sample_encode_as_serialized_proto(SentencePieceProcessor *spp, char const *sentence, size_t sentence_len, size_t *len, size_t nbest, float alpha);
+
 SentencePieceProcessor *spp_new();
 
 int spp_from_serialized_proto(SentencePieceProcessor *spp, char const *data, size_t len);


### PR DESCRIPTION
This method encodes an input with subword regularization (Kudo, 2018).

Fixes #56.