### PR TITLE
Remove Eq

### DIFF
--- a/sentencepiece/src/lib.rs
+++ b/sentencepiece/src/lib.rs
@@ -156,7 +156,7 @@ impl SentencePieceProcessor {
         if result == 0 {
             Ok(spp)
         } else {
-            let c_error = match FromPrimitive::from_i32(result as i32) {
+            let c_error = match FromPrimitive::from_i32(result) {
                 Some(error) => error,
                 None => unreachable!(),
             };
@@ -189,7 +189,7 @@ impl SentencePieceProcessor {
         if result == 0 {
             Ok(spp)
         } else {
-            let c_error = match FromPrimitive::from_i32(result as i32) {
+            let c_error = match FromPrimitive::from_i32(result) {
                 Some(error) => error,
                 None => unreachable!(),
             };
@@ -232,7 +232,7 @@ impl SentencePieceProcessor {
 
             Ok(decoded_string)
         } else {
-            let c_error = match FromPrimitive::from_i32(status as i32) {
+            let c_error = match FromPrimitive::from_i32(status) {
                 Some(error) => error,
                 None => unreachable!(),
             };
@@ -275,7 +275,7 @@ impl SentencePieceProcessor {
 
             Ok(decoded_string)
         } else {
-            let c_error = match FromPrimitive::from_i32(status as i32) {
+            let c_error = match FromPrimitive::from_i32(status) {
                 Some(error) => error,
                 None => unreachable!(),
             };

--- a/sentencepiece/src/sentencepiece.rs
+++ b/sentencepiece/src/sentencepiece.rs
@@ -1,6 +1,6 @@
 use prost_derive::Message;
 
-#[derive(Clone, Eq, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct SentencePieceText {
     /// User input or postprocessed text.
     #[prost(string, optional, tag = "1")]
@@ -15,7 +15,7 @@ pub struct SentencePieceText {
     pub score: Option<f32>,
 }
 
-#[derive(Clone, Eq, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct SentencePiece {
     /// Internal representation for the decoder.
     #[prost(string, optional, tag = "1")]


### PR DESCRIPTION
Hey there! Many thanks for this binding! 

Installing sentencepiece fails because `the trait 'std::cmp::Eq' is not implemented for 'f32'`
Am I missing something?

Platform: v1.68.0-nightly