### PR TITLE
Update documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This Rust crate is a binding for the
 [sentencepiece](https://github.com/google/sentencepiece) unsupervised
 text tokenizer. The [crate
-documentation](https://rustdoc.danieldk.eu/sentencepiece) is available
+documentation](https://docs.rs/sentencepiece/) is available
 online.
 
 ## `libsentencepiece` dependency


### PR DESCRIPTION
Replaced the outdated link to the crate documentation with the correct URL pointing to docs.rs. This ensures users are directed to the proper resource for reference.

This PR fixes #70.