### PR TITLE
Fix CI errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,33 +7,17 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all --check
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+      - run: cargo clippy -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,25 +20,18 @@ jobs:
     name: Test without libsentencepiece
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-      - uses: actions/cache@v3
+      - run: rustup override set ${{ matrix.toolchain }}
+      - uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
+            ~/.cargo/registry
+            ~/.cargo/git
             target/
           key: ${{ runner.os }}-${{ matrix.toolchain }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.target-features }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo test
       - name: Run tests (macOS, Intel)
         if: matrix.os == 'macos-13'
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macos-13
           - macos-latest
         toolchain:
           - stable
@@ -38,11 +39,16 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-      - name: Run tests (macOS)
-        if: matrix.os == 'macos-latest'
+      - name: Run tests (macOS, Intel)
+        if: matrix.os == 'macos-13'
         env:
           RUSTFLAGS: "-Ctarget-feature=${{ matrix.target-features }}"
         run: scripts/test-all.sh --target x86_64-apple-darwin
+      - name: Run tests (macOS, Apple silicon)
+        if: matrix.os == 'macos-latest'
+        env:
+          RUSTFLAGS: "-Ctarget-feature=${{ matrix.target-features }}"
+        run: scripts/test-all.sh --target aarch64-apple-darwin
       - name: Run tests (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && matrix.target-features != '+crt-static'
         env:

--- a/sentencepiece/Cargo.toml
+++ b/sentencepiece/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["testdata/albert-base-v1-spiece.model"]
 
 [dependencies]
 libc = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 num-traits = "0.2"
 prost = "0.11"
 prost-derive = "0.11"

--- a/sentencepiece/src/lib.rs
+++ b/sentencepiece/src/lib.rs
@@ -302,7 +302,7 @@ impl SentencePieceProcessor {
             spp_encode_as_serialized_proto(
                 self.inner,
                 sentence.as_ptr() as *const c_char,
-                sentence.as_bytes().len(),
+                sentence.len(),
                 &mut len,
             )
         };
@@ -352,7 +352,7 @@ impl SentencePieceProcessor {
 
     fn process_encode_protobuf(c_proto: CData) -> Result<Vec<PieceWithId>, SentencePieceError> {
         // Errors are communicated as empty data.
-        if c_proto.len() == 0 {
+        if c_proto.is_empty() {
             return Err(SentencePieceError::EncodeError);
         }
 
@@ -407,7 +407,7 @@ impl SentencePieceProcessor {
             spp_sample_encode_as_serialized_proto(
                 self.inner,
                 sentence.as_ptr() as *const c_char,
-                sentence.as_bytes().len(),
+                sentence.len(),
                 &mut len,
                 n_best,
                 alpha,


### PR DESCRIPTION
This PR fixes [the CI errors](https://github.com/danieldk/sentencepiece/actions/runs/14538954035) by:
- Fixing the target for Apple Silicon Mac
- Fixing Clippy errors
- Simplifying workflows based on [Building and testing Rust](https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-rust)