### PR TITLE
Update cmake version policy to 3.10

### DIFF
--- a/sentencepiece-sys/build.rs
+++ b/sentencepiece-sys/build.rs
@@ -7,7 +7,7 @@ macro_rules! feature(($name:expr) => (env::var(concat!("CARGO_FEATURE_", $name))
 
 fn build_sentencepiece(builder: &mut Build) {
     let mut config = Config::new("source");
-    config.define("CMAKE_POLICY_VERSION_MINIMUM", "3.5");
+    config.define("CMAKE_POLICY_VERSION_MINIMUM", "3.10");
     if builder.get_compiler().is_like_msvc() {
         config.profile("Release");
         if env::var("CARGO_CFG_TARGET_FEATURE")


### PR DESCRIPTION
Pull request referencing the issue I posted. Bumps the minimum required cmake version from 3.5 to 3.10

fixes #81 